### PR TITLE
Fix upstream remote configuration to respect target.yml org changes

### DIFF
--- a/gen-and-run-tasks.sh
+++ b/gen-and-run-tasks.sh
@@ -368,6 +368,25 @@ if [[ "$RUN_ONLY" != "true" ]]; then
 
         if [[ -d "$repo_dir" ]]; then
             echo "   ✅ Repository $repo already exists in workspace"
+
+            # Update upstream remote if it differs from the configured org
+            echo "   🔗 Verifying upstream remote for $org/$repo..."
+            cd "$repo_dir"
+            local current_upstream=$(git remote get-url upstream 2>/dev/null || echo "")
+            local expected_upstream="https://github.com/$org/$repo.git"
+
+            if [[ "$current_upstream" != "$expected_upstream" ]]; then
+                echo "   🔄 Updating upstream from $current_upstream to $expected_upstream"
+                if [[ -n "$current_upstream" ]]; then
+                    git remote set-url upstream "$expected_upstream"
+                else
+                    git remote add upstream "$expected_upstream"
+                fi
+            else
+                echo "   ✅ Upstream remote already correct: $expected_upstream"
+            fi
+            cd - > /dev/null
+
             return 0
         fi
 


### PR DESCRIPTION
## Summary
- Fix upstream remote not updating when using existing workspace repos with different organizations
- Ensure upstream remote always matches the organization specified in target.yml

## Changes
- Modified `ensure_repo_exists` function to verify and update upstream remote for existing repositories
- Added comparison between current upstream URL and expected URL from target.yml
- Automatically updates upstream if organization has changed between bundle executions

## Problem
Previously, when a repository already existed in the workspace (e.g., `workspace/ocm`), the script would skip all remote configuration. This caused issues when:
1. Using the same repository with different organizations in different bundles
2. Example: `bundles/01-base-image/target.yml` uses `org: stolostron`
3. Example: `bundles/04-cve-x-net-helm/target.yml` uses `org: open-cluster-management-io`

The upstream would remain pointing to whichever organization was used during the initial clone, ignoring subsequent bundle configurations.

## Solution
Now the script:
1. Checks if repository exists in workspace
2. Verifies the current upstream remote URL
3. Compares it against the expected URL from target.yml
4. Updates the upstream if they differ
5. Provides clear feedback about the upstream status

## Test Plan
- [x] Tested with existing workspace/ocm repository
- [x] Verified upstream updates from `stolostron/ocm` to `open-cluster-management-io/ocm`
- [x] Verified correct messaging for both update and no-change scenarios
- [x] Tested with multiple bundles using different organizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)